### PR TITLE
LAUN-309: Support additional parameters for auth requests, convenience function around idToken

### DIFF
--- a/OLOidc.xcodeproj/project.pbxproj
+++ b/OLOidc.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 		58D2D25723BA2765008DC877 /* OLOidcTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OLOidcTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		58D2D25C23BA2765008DC877 /* ios_oidcTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ios_oidcTests.swift; sourceTree = "<group>"; };
 		58D2D25E23BA2765008DC877 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		58D2D2DF23BA2FE4008DC877 /* OLOidc-tester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OLOidc-tester.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		58D2D2DF23BA2FE4008DC877 /* ios-oidc-swift-tester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-oidc-swift-tester.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		58D2D2E123BA2FE4008DC877 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		58D2D2E323BA2FE4008DC877 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		58D2D2E523BA2FE4008DC877 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -327,7 +327,7 @@
 				587DCB0923BA7F420071EF27 /* README.md */,
 				58D2D25023BA2765008DC877 /* ios-oidc */,
 				58D2D25B23BA2765008DC877 /* ios-oidcTests */,
-				58D2D2E023BA2FE4008DC877 /* ios-oidc-tester */,
+				58D2D2E023BA2FE4008DC877 /* ios-oidc-swift-tester */,
 				58D2D2F723BA2FE5008DC877 /* ios-oidc-testerTests */,
 				58D2D30223BA2FE5008DC877 /* ios-oidc-testerUITests */,
 				58DE83C623FEE76400F48106 /* ios-oidc-objc-tester */,
@@ -341,7 +341,7 @@
 			children = (
 				58D2D24E23BA2765008DC877 /* OLOidc.framework */,
 				58D2D25723BA2765008DC877 /* OLOidcTests.xctest */,
-				58D2D2DF23BA2FE4008DC877 /* OLOidc-tester.app */,
+				58D2D2DF23BA2FE4008DC877 /* ios-oidc-swift-tester.app */,
 				58D2D2F423BA2FE5008DC877 /* OLOidc-testerTests.xctest */,
 				58D2D2FF23BA2FE5008DC877 /* OLOidc-testerUITests.xctest */,
 				58DE83C523FEE76400F48106 /* ios-oidc-objc-tester.app */,
@@ -369,7 +369,7 @@
 			path = "ios-oidcTests";
 			sourceTree = "<group>";
 		};
-		58D2D2E023BA2FE4008DC877 /* ios-oidc-tester */ = {
+		58D2D2E023BA2FE4008DC877 /* ios-oidc-swift-tester */ = {
 			isa = PBXGroup;
 			children = (
 				58D2D2E123BA2FE4008DC877 /* AppDelegate.swift */,
@@ -381,7 +381,7 @@
 				58D2D2EF23BA2FE5008DC877 /* Info.plist */,
 				58DE838223F6E5CD00F48106 /* OL-Oidc.plist */,
 			);
-			path = "ios-oidc-tester";
+			path = "ios-oidc-swift-tester";
 			sourceTree = "<group>";
 		};
 		58D2D2F723BA2FE5008DC877 /* ios-oidc-testerTests */ = {
@@ -619,9 +619,9 @@
 			productReference = 58D2D25723BA2765008DC877 /* OLOidcTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		58D2D2DE23BA2FE4008DC877 /* OLOidc-tester */ = {
+		58D2D2DE23BA2FE4008DC877 /* ios-oidc-swift-tester */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 58D2D30623BA2FE5008DC877 /* Build configuration list for PBXNativeTarget "OLOidc-tester" */;
+			buildConfigurationList = 58D2D30623BA2FE5008DC877 /* Build configuration list for PBXNativeTarget "ios-oidc-swift-tester" */;
 			buildPhases = (
 				58D2D2DB23BA2FE4008DC877 /* Sources */,
 				58D2D2DC23BA2FE4008DC877 /* Frameworks */,
@@ -633,9 +633,9 @@
 			dependencies = (
 				58D2D3AD23BA7C74008DC877 /* PBXTargetDependency */,
 			);
-			name = "OLOidc-tester";
+			name = "ios-oidc-swift-tester";
 			productName = "ios-oidc-tester";
-			productReference = 58D2D2DF23BA2FE4008DC877 /* OLOidc-tester.app */;
+			productReference = 58D2D2DF23BA2FE4008DC877 /* ios-oidc-swift-tester.app */;
 			productType = "com.apple.product-type.application";
 		};
 		58D2D2F323BA2FE5008DC877 /* OLOidc-testerTests */ = {
@@ -739,7 +739,7 @@
 			targets = (
 				58D2D24D23BA2765008DC877 /* OLOidc */,
 				58D2D25623BA2765008DC877 /* OLOidcTests */,
-				58D2D2DE23BA2FE4008DC877 /* OLOidc-tester */,
+				58D2D2DE23BA2FE4008DC877 /* ios-oidc-swift-tester */,
 				58D2D2F323BA2FE5008DC877 /* OLOidc-testerTests */,
 				58D2D2FE23BA2FE5008DC877 /* OLOidc-testerUITests */,
 				58DE83C423FEE76400F48106 /* ios-oidc-objc-tester */,
@@ -911,12 +911,12 @@
 		};
 		58D2D2F623BA2FE5008DC877 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 58D2D2DE23BA2FE4008DC877 /* OLOidc-tester */;
+			target = 58D2D2DE23BA2FE4008DC877 /* ios-oidc-swift-tester */;
 			targetProxy = 58D2D2F523BA2FE5008DC877 /* PBXContainerItemProxy */;
 		};
 		58D2D30123BA2FE5008DC877 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 58D2D2DE23BA2FE4008DC877 /* OLOidc-tester */;
+			target = 58D2D2DE23BA2FE4008DC877 /* ios-oidc-swift-tester */;
 			targetProxy = 58D2D30023BA2FE5008DC877 /* PBXContainerItemProxy */;
 		};
 		58D2D3AD23BA7C74008DC877 /* PBXTargetDependency */ = {
@@ -1179,13 +1179,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 2YX6A8Z383;
-				INFOPLIST_FILE = "ios-oidc-tester/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-oidc-swift-tester/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onelogin.ios-oidc-tester";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "ios-oidc-swift-tester";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1197,13 +1197,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 2YX6A8Z383;
-				INFOPLIST_FILE = "ios-oidc-tester/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-oidc-swift-tester/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onelogin.ios-oidc-tester";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "ios-oidc-swift-tester";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1357,7 +1357,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		58D2D30623BA2FE5008DC877 /* Build configuration list for PBXNativeTarget "OLOidc-tester" */ = {
+		58D2D30623BA2FE5008DC877 /* Build configuration list for PBXNativeTarget "ios-oidc-swift-tester" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58D2D30723BA2FE5008DC877 /* Debug */,

--- a/OLOidc.xcodeproj/xcshareddata/xcschemes/OLOidc-tester.xcscheme
+++ b/OLOidc.xcodeproj/xcshareddata/xcschemes/OLOidc-tester.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58D2D2DE23BA2FE4008DC877"
+               BuildableName = "ios-oidc-swift-tester.app"
+               BlueprintName = "ios-oidc-swift-tester"
+               ReferencedContainer = "container:OLOidc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58D2D2F323BA2FE5008DC877"
+               BuildableName = "OLOidc-testerTests.xctest"
+               BlueprintName = "OLOidc-testerTests"
+               ReferencedContainer = "container:OLOidc.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58D2D2FE23BA2FE5008DC877"
+               BuildableName = "OLOidc-testerUITests.xctest"
+               BlueprintName = "OLOidc-testerUITests"
+               ReferencedContainer = "container:OLOidc.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "58D2D2DE23BA2FE4008DC877"
+            BuildableName = "ios-oidc-swift-tester.app"
+            BlueprintName = "ios-oidc-swift-tester"
+            ReferencedContainer = "container:OLOidc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "58D2D2DE23BA2FE4008DC877"
+            BuildableName = "ios-oidc-swift-tester.app"
+            BlueprintName = "ios-oidc-swift-tester"
+            ReferencedContainer = "container:OLOidc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Required parameters are:
  - clientId
  - redirectUri
  - scopes (requires at least `openid`, values are space separated)
+ 
+Additionally you can add as many custom parameters as you want. For example you can add
+```swift
+"resource": "https://api.example.com/contacts"
+```
+to your plist file in order to generate a custom access token. You can read about additional parameters on the [OIDC Auth Code Flow](https://developers.onelogin.com/openid-connect/api/authorization-code) page.
 
 ## Authorization redirect
 
@@ -128,7 +134,7 @@ olOidc?.olAuthState.deleteFromKeychain()
 
 ### signIn
 
-To start the authorization you have to initialize an `OLOidc` object and call `signIn`. The function will return an error in the callback if something goes wrong. If the authorization was successful, the response data will be saved securely in the keychain and you can access it easily through the `OLOidcAuthState`object:
+To start the authorization you have to initialize an `OLOidc` object and call `signIn`. The function will return an error in the callback if something goes wrong. If the authorization was successful, the response data will be saved securely in the keychain and you can access it easily through the `OLOidcAuthState`object. Besides the pure idToken you can use  idTokenParsed` to directly access properties like the claims or audience for that token:
 
 ```swift
 olOidc?.signIn(presenter: self) { error in
@@ -136,6 +142,7 @@ olOidc?.signIn(presenter: self) { error in
         let accessToken = self.olOidc?.olAuthState.accessToken
         let refreshToken = self.olOidc?.olAuthState.refreshToken
         let idToken = self.olOidc?.olAuthState.idToken
+        let claims = self.olOidc?.olAuthState.idTokenParsed?.claims
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To get more info about how to configure an app for OIDC visit the [Overview of O
   - [revokeToken](#revokeToken)
   - [introspect](#introspect)
   - [getUserInfo](#getuserinfo)
+  - [refreshAccessToken](#refreshAccessToken)
 
 <!-- /TOC -->
 
@@ -196,5 +197,19 @@ olOidc?.getUserInfo(callback: { (userInfo, error) in
                 return
             }
             print("\(String(describing: userInfo))")
+        })
+```
+
+### refreshAccessToken
+
+To refresh an access token you can call the `refreshAccessToken` function:
+
+```swift
+olOidc?.refreshAccessToken(callback: { (error) in
+            if let error = error {
+                // some error occured
+                return
+            }
+            // Successfully refreshed access token
         })
 ```

--- a/ios-oidc-objc-tester/Base.lproj/Main.storyboard
+++ b/ios-oidc-objc-tester/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                                 <rect key="frame" x="20.666666666666657" y="67.333333333333314" width="372.66666666666674" height="761.33333333333348"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="lQI-3m-NLG">
-                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="126"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jVT-rg-SZ7">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -66,10 +66,25 @@
                                                     <action selector="btnGetUserInfoClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x3W-dU-db2"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HSG-cY-BZM" userLabel="Refresh access token">
+                                                <rect key="frame" x="0.0" y="96.000000000000014" width="372.66666666666669" height="30"/>
+                                                <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
+                                                <state key="normal" title="Refresh access token">
+                                                    <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="15"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="btnRefreshAccessTokenClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8d0-o3-4uF"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eXE-2C-SMi">
-                                        <rect key="frame" x="0.0" y="114" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="146" width="372.66666666666669" height="94"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IjV-HD-ccx">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -102,7 +117,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5yB-8l-Z6b">
-                                                <rect key="frame" x="0.0" y="64" width="372.66666666666669" height="30"/>
+                                                <rect key="frame" x="0.0" y="63.999999999999972" width="372.66666666666669" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
                                                 <state key="normal" title="Revoke Refresh-Token">
                                                     <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,7 +134,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-2Y-yBe">
-                                        <rect key="frame" x="0.0" y="228.00000000000003" width="372.66666666666669" height="86.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="260" width="372.66666666666669" height="54.333333333333314"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/ios-oidc-objc-tester/ViewController.m
+++ b/ios-oidc-objc-tester/ViewController.m
@@ -85,4 +85,15 @@
     }];
 }
 
+- (IBAction)btnRefreshAccessTokenClicked:(id)sender {
+    [self.olOidc refreshAccessTokenWithCallback:^(NSError * error) {
+        if (error != nil) {
+            [self setInfoText:[@"Error refreshing access token: " stringByAppendingString:error.localizedDescription]];
+            return;
+        }
+        [self setInfoText:@"Successfully refreshed access token"];
+    }];
+}
+
+
 @end

--- a/ios-oidc-swift-tester/Base.lproj/Main.storyboard
+++ b/ios-oidc-swift-tester/Base.lproj/Main.storyboard
@@ -10,7 +10,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="OLOidc_tester" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ios_oidc_swift_tester" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -19,7 +19,7 @@
                                 <rect key="frame" x="20.666666666666657" y="100.33333333333331" width="372.66666666666674" height="695.33333333333348"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eRe-zk-tn6">
-                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="126"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6TA-kl-cNi">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -66,10 +66,25 @@
                                                     <action selector="btnGetUserInfoClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SoB-TR-rsc"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZgE-Nx-zeA" userLabel="Refresh access token">
+                                                <rect key="frame" x="0.0" y="96.000000000000014" width="372.66666666666669" height="30"/>
+                                                <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
+                                                <state key="normal" title="Refresh access token">
+                                                    <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="15"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="btnRefreshAccessTokenClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vew-Wu-oRz"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eDp-eE-cgm">
-                                        <rect key="frame" x="0.0" y="114" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="146" width="372.66666666666669" height="94"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8NK-P1-M9j">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -87,7 +102,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="47H-La-B1Z">
-                                                <rect key="frame" x="0.0" y="32" width="372.66666666666669" height="30"/>
+                                                <rect key="frame" x="0.0" y="31.999999999999972" width="372.66666666666669" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
                                                 <state key="normal" title="Revoke Access-Token">
                                                     <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,13 +134,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Ka-zb-bYE">
-                                        <rect key="frame" x="0.0" y="228" width="372.66666666666669" height="20.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="260" width="372.66666666666669" height="20.333333333333314"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uax-kc-u0J">
-                                        <rect key="frame" x="0.0" y="268.33333333333337" width="372.66666666666669" height="427"/>
+                                        <rect key="frame" x="0.0" y="300.33333333333337" width="372.66666666666669" height="395"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/ios-oidc-swift-tester/ViewController.swift
+++ b/ios-oidc-swift-tester/ViewController.swift
@@ -82,5 +82,16 @@ class ViewController: UIViewController {
             self.setInfoText(text: "Successfully revoked Refresh-Token")
         })
     }
+    
+    @IBAction func btnRefreshAccessTokenClicked(_ sender: Any) {
+        olOidc?.refreshAccessToken(callback: { (error) in
+            if let error = error {
+                self.setInfoText(text: error.localizedDescription)
+                return
+            }
+            self.setInfoText(text: "Successfully refreshed access token")
+        })
+    }
+    
 }
 

--- a/ios-oidc/Oidc/OLOidc.swift
+++ b/ios-oidc/Oidc/OLOidc.swift
@@ -205,4 +205,16 @@ public class OLOidc: NSObject {
             task.resume()
         }
     }
+    
+    @objc public func refreshAccessToken(callback: @escaping ((Error?) -> Void)) {
+        olAuthState.authState?.setNeedsTokenRefresh()
+        olAuthState.authState?.performAction(freshTokens: { (freshAccessToken, idToken, error) in
+            if error != nil {
+                callback(error)
+                return
+            }
+            self.olAuthState.authState = self.olAuthState.authState
+            callback(nil)
+        })
+    }
 }

--- a/ios-oidc/Oidc/OLOidc.swift
+++ b/ios-oidc/Oidc/OLOidc.swift
@@ -48,7 +48,7 @@ public class OLOidc: NSObject {
                                                   scopes: self.oidcConfig.getScopes(),
                                                   redirectURL: self.oidcConfig.redirectUri,
                                                   responseType: OIDResponseTypeCode,
-                                                  additionalParameters: nil)
+                                                  additionalParameters: self.oidcConfig.additionalParameters)
 
             let externalUserAgent = OIDExternalUserAgentIOS(presenting: presenter)
             self.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, externalUserAgent: externalUserAgent!) { (authState, error) in

--- a/ios-oidc/Oidc/OLOidcAuthState.swift
+++ b/ios-oidc/Oidc/OLOidcAuthState.swift
@@ -26,6 +26,9 @@ open class OLOidcAuthState: NSObject {
     @objc open var idToken: String? {
         get {return authState?.lastTokenResponse?.idToken}
     }
+    @objc open var idTokenParsed: OIDIDToken? {
+        get {return OIDIDToken(idTokenString: authState?.lastTokenResponse?.idToken ?? "")}
+    }
     @objc open var refreshToken: String? {
         get {return authState?.lastTokenResponse?.refreshToken}
     }

--- a/ios-oidc/Oidc/OLOidcConfig.swift
+++ b/ios-oidc/Oidc/OLOidcConfig.swift
@@ -10,24 +10,32 @@ import Foundation
 
 public class OLOidcConfig: NSObject, Codable {
 
+    private static let Issuer = "issuer"
+    private static let ClientId = "clientId"
+    private static let RedirectUri = "redirectUri"
+    private static let Scopes = "scopes"
+    private static let ScopeOpenId = "openid"
+    private static let requiredParams = [Issuer, ClientId, RedirectUri, Scopes]
+    
     @objc public static let stdConfigName = "OL-Oidc"
     @objc public let clientId: String
     @objc public let issuer: String
     @objc public let redirectUri: URL
     @objc private let scopes: String
     @objc public let loginUrl: URL?
+    @objc public let additionalParameters: [String:String]?
 
     @objc public static func standard() throws -> OLOidcConfig {
         return try OLOidcConfig(plist: stdConfigName)
     }
     
     @objc public init(dict: [String: String]) throws {
-        guard let clientId = dict["clientId"], clientId.count > 0,
-              let issuer = dict["issuer"],
+        guard let clientId = dict[OLOidcConfig.ClientId], clientId.count > 0,
+            let issuer = dict[OLOidcConfig.Issuer],
               let _ = URL(string: issuer),
-              let redirectUriString = dict["redirectUri"],
+              let redirectUriString = dict[OLOidcConfig.RedirectUri],
               let redirectUri = URL(string: redirectUriString),
-              let scopes = dict["scopes"], scopes.contains("openid")
+              let scopes = dict[OLOidcConfig.Scopes], scopes.contains(OLOidcConfig.ScopeOpenId)
                else {
                 throw OLOidcError.configInvalid
         }
@@ -37,6 +45,16 @@ public class OLOidcConfig: NSObject, Codable {
         self.redirectUri = redirectUri
         self.scopes = scopes
         self.loginUrl = nil
+        self.additionalParameters = OLOidcConfig.getAdditionalParameters(dict: dict)
+    }
+    
+    private static func getAdditionalParameters(dict: [String: String]) -> [String: String]? {
+        // cut out required parameters
+        var additionalParams = dict
+        for param in requiredParams {
+            additionalParams.removeValue(forKey: param)
+        }
+        return additionalParams.count > 0 ? additionalParams : nil
     }
     
     @objc public convenience init(plist: String) throws {


### PR DESCRIPTION
- the SDK now supports additional parameters that can be set in the configuration plist file or directly during dictionary initialization
- added an idTokenParsed property so that fields like `claims` or `audience` can be accessed more convenient
- updated the readme file to reflect the new changes
- fixed project structure as we shifted over to a new repository and some files have been renamed without reflecting these changes in the project file
