### PR TITLE
Laun-311: Expand the SDK API with refreshToken functionality so that the user can do a manual refresh if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To get more info about how to configure an app for OIDC visit the [Overview of O
   - [revokeToken](#revokeToken)
   - [introspect](#introspect)
   - [getUserInfo](#getuserinfo)
+  - [refreshAccessToken](#refreshAccessToken)
 
 <!-- /TOC -->
 
@@ -196,5 +197,19 @@ olOidc?.getUserInfo(callback: { (userInfo, error) in
                 return
             }
             print("\(String(describing: userInfo))")
+        })
+```
+
+### refreshAccessToken
+
+To refresh an access token you can call the `refreshAccessToken` function:
+
+```swift
+olOidc?.refreshAccessToken(callback: { (error) in
+            if let error = error {
+                // some error occured
+                return
+            }
+            // Successfully refreshed access token
         })
 ```

--- a/ios-oidc-objc-tester/Base.lproj/Main.storyboard
+++ b/ios-oidc-objc-tester/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                                 <rect key="frame" x="20.666666666666657" y="67.333333333333314" width="372.66666666666674" height="761.33333333333348"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="lQI-3m-NLG">
-                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="126"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jVT-rg-SZ7">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -66,10 +66,25 @@
                                                     <action selector="btnGetUserInfoClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x3W-dU-db2"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HSG-cY-BZM" userLabel="Refresh access token">
+                                                <rect key="frame" x="0.0" y="96.000000000000014" width="372.66666666666669" height="30"/>
+                                                <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
+                                                <state key="normal" title="Refresh access token">
+                                                    <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="15"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="btnRefreshAccessTokenClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8d0-o3-4uF"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eXE-2C-SMi">
-                                        <rect key="frame" x="0.0" y="114" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="146" width="372.66666666666669" height="94"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IjV-HD-ccx">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -102,7 +117,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5yB-8l-Z6b">
-                                                <rect key="frame" x="0.0" y="64" width="372.66666666666669" height="30"/>
+                                                <rect key="frame" x="0.0" y="63.999999999999972" width="372.66666666666669" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
                                                 <state key="normal" title="Revoke Refresh-Token">
                                                     <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,7 +134,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-2Y-yBe">
-                                        <rect key="frame" x="0.0" y="228.00000000000003" width="372.66666666666669" height="86.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="260" width="372.66666666666669" height="54.333333333333314"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/ios-oidc-objc-tester/ViewController.m
+++ b/ios-oidc-objc-tester/ViewController.m
@@ -85,4 +85,15 @@
     }];
 }
 
+- (IBAction)btnRefreshAccessTokenClicked:(id)sender {
+    [self.olOidc refreshAccessTokenWithCallback:^(NSError * error) {
+        if (error != nil) {
+            [self setInfoText:[@"Error refreshing access token: " stringByAppendingString:error.localizedDescription]];
+            return;
+        }
+        [self setInfoText:@"Successfully refreshed access token"];
+    }];
+}
+
+
 @end

--- a/ios-oidc-swift-tester/Base.lproj/Main.storyboard
+++ b/ios-oidc-swift-tester/Base.lproj/Main.storyboard
@@ -10,7 +10,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="OLOidc_tester" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ios_oidc_swift_tester" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -19,7 +19,7 @@
                                 <rect key="frame" x="20.666666666666657" y="100.33333333333331" width="372.66666666666674" height="695.33333333333348"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eRe-zk-tn6">
-                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="126"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6TA-kl-cNi">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -66,10 +66,25 @@
                                                     <action selector="btnGetUserInfoClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SoB-TR-rsc"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZgE-Nx-zeA" userLabel="Refresh access token">
+                                                <rect key="frame" x="0.0" y="96.000000000000014" width="372.66666666666669" height="30"/>
+                                                <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
+                                                <state key="normal" title="Refresh access token">
+                                                    <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="15"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="btnRefreshAccessTokenClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vew-Wu-oRz"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="eDp-eE-cgm">
-                                        <rect key="frame" x="0.0" y="114" width="372.66666666666669" height="94"/>
+                                        <rect key="frame" x="0.0" y="146" width="372.66666666666669" height="94"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8NK-P1-M9j">
                                                 <rect key="frame" x="0.0" y="0.0" width="372.66666666666669" height="30"/>
@@ -87,7 +102,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="47H-La-B1Z">
-                                                <rect key="frame" x="0.0" y="32" width="372.66666666666669" height="30"/>
+                                                <rect key="frame" x="0.0" y="31.999999999999972" width="372.66666666666669" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.46666666670000001" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
                                                 <state key="normal" title="Revoke Access-Token">
                                                     <color key="titleColor" red="0.96862745100000003" green="0.97647058819999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,13 +134,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Ka-zb-bYE">
-                                        <rect key="frame" x="0.0" y="228" width="372.66666666666669" height="20.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="260" width="372.66666666666669" height="20.333333333333314"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uax-kc-u0J">
-                                        <rect key="frame" x="0.0" y="268.33333333333337" width="372.66666666666669" height="427"/>
+                                        <rect key="frame" x="0.0" y="300.33333333333337" width="372.66666666666669" height="395"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/ios-oidc-swift-tester/ViewController.swift
+++ b/ios-oidc-swift-tester/ViewController.swift
@@ -82,5 +82,16 @@ class ViewController: UIViewController {
             self.setInfoText(text: "Successfully revoked Refresh-Token")
         })
     }
+    
+    @IBAction func btnRefreshAccessTokenClicked(_ sender: Any) {
+        olOidc?.refreshAccessToken(callback: { (error) in
+            if let error = error {
+                self.setInfoText(text: error.localizedDescription)
+                return
+            }
+            self.setInfoText(text: "Successfully refreshed access token")
+        })
+    }
+    
 }
 

--- a/ios-oidc/Oidc/OLOidc.swift
+++ b/ios-oidc/Oidc/OLOidc.swift
@@ -205,4 +205,16 @@ public class OLOidc: NSObject {
             task.resume()
         }
     }
+    
+    @objc public func refreshAccessToken(callback: @escaping ((Error?) -> Void)) {
+        olAuthState.authState?.setNeedsTokenRefresh()
+        olAuthState.authState?.performAction(freshTokens: { (freshAccessToken, idToken, error) in
+            if error != nil {
+                callback(error)
+                return
+            }
+            self.olAuthState.authState = self.olAuthState.authState
+            callback(nil)
+        })
+    }
 }


### PR DESCRIPTION
- added API to refresh an access token
- updated Swift and ObjC tester with refresh functionality
- updated Readme to reflect changes
